### PR TITLE
Allow importing GPG key as a base64 string

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,23 @@ ___
 
 ## Prerequisites
 
-First, export the GPG private key as an ASCII armored version:
+First, export the GPG private key as an ASCII armored version to your clipboard:
 
 ```shell
-gpg --armor --export-secret-key --output key.pgp joe@foo.bar
+# macOS
+gpg --armor --export-secret-key joe@foo.bar | pbcopy
+
+# Ubuntu (assuming GNU base64)
+gpg --armor --export-secret-key joe@foo.bar -w0 | xclip
+
+# Arch
+gpg --armor --export-secret-key joe@foo.bar | sed -z 's;\n;;g' | xclip -selection clipboard -i
+
+# FreeBSD (assuming BSD base64)
+gpg --armor --export-secret-key joe@foo.bar | xclip
 ```
 
-Copy the content of `key.pgp` file as a [`secret`](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) named `GPG_PRIVATE_KEY` for example. Create another secret with the `PASSPHRASE` if applicable.
+Paste your clipboard as a [`secret`](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) named `GPG_PRIVATE_KEY` for example. Create another secret with the `PASSPHRASE` if applicable.
 
 ## Usage
 
@@ -141,11 +151,11 @@ Following outputs are available
 
 ### environment variables
 
-Following environment variables can be used as `step.env` keys
+Following environment variables must be used as `step.env` keys
 
 | Name               | Description                           |
 |--------------------|---------------------------------------|
-| `GPG_PRIVATE_KEY`  | GPG private key exported as an ASCII armored version (**required**) |
+| `GPG_PRIVATE_KEY`  | GPG private key exported as an ASCII armored version or its base64 encoding (**required**) |
 | `PASSPHRASE`       | Passphrase of the `GPG_PRIVATE_KEY` key if setted |
 
 ## How can I help?

--- a/__tests__/openpgp.test.ts
+++ b/__tests__/openpgp.test.ts
@@ -116,8 +116,16 @@ PejgXO0uIRolYQ3sz2tMGhx1MfBqH64=
 
 describe('openpgp', () => {
   describe('readPrivateKey', () => {
-    it('returns a PGP private key', async () => {
+    it('returns a PGP private key from an armored string', async () => {
       await openpgp.readPrivateKey(userInfo.pgp).then(privateKey => {
+        expect(privateKey.keyID).toEqual(userInfo.keyID);
+        expect(privateKey.name).toEqual(userInfo.name);
+        expect(privateKey.email).toEqual(userInfo.email);
+        expect(privateKey.fingerprint).toEqual(userInfo.fingerprint);
+      });
+    });
+    it('returns a PGP private key from a base64 armored string', async () => {
+      await openpgp.readPrivateKey(Buffer.from(userInfo.pgp).toString('base64')).then(privateKey => {
         expect(privateKey.keyID).toEqual(userInfo.keyID);
         expect(privateKey.name).toEqual(userInfo.name);
         expect(privateKey.email).toEqual(userInfo.email);

--- a/src/openpgp.ts
+++ b/src/openpgp.ts
@@ -18,7 +18,8 @@ export const readPrivateKey = async (armoredText: string): Promise<PrivateKey> =
   const {
     keys: [privateKey],
     err: err
-  } = await openpgp.key.readArmored(armoredText);
+  } = await openpgp.key.readArmored(isArmored(armoredText) ? armoredText : Buffer.from(armoredText, 'base64').toString());
+
   if (err?.length) {
     throw err[0];
   }
@@ -51,3 +52,5 @@ export const generateKeyPair = async (name: string, email: string, passphrase: s
     privateKey: keyPair.privateKeyArmored.replace(/\r\n/g, '\n').trim()
   };
 };
+
+const isArmored = (text: string) => text.trimLeft().startsWith('---');


### PR DESCRIPTION
# What has been done in this PR?

Add the possibility to import the GPG private key from a base64 encoded string.

# Why this change?

There are multiple tooling out there that handle GPG keys as a base64 encoded string of its armored version. With this change this action can be used in cojunction with such tooling without needing to have two different secrets with the "same" information.
