### PR TITLE
Added support for subkeys via env.FINGERPRINT

### DIFF
--- a/src/gpg.ts
+++ b/src/gpg.ts
@@ -130,8 +130,12 @@ export const getKeygrip = async (fingerprint: string): Promise<string> => {
       throw new Error(res.stderr);
     }
     let keygrip: string = '';
+    let fpr_found: boolean = false;
     for (let line of res.stdout.replace(/\r/g, '').trim().split(/\n/g)) {
-      if (line.startsWith('grp')) {
+      if (line.startsWith('fpr')) {
+        let fpr = line.replace(/(fpr|:)/g, '').trim();
+        fpr_found = fpr == fingerprint;
+      } else if (fpr_found && line.startsWith('grp')) {
         keygrip = line.replace(/(grp|:)/g, '').trim();
         break;
       }


### PR DESCRIPTION
We follow best practices from Debian (https://wiki.debian.org/Subkeys) and we only deploy secret-subkeys (as exported by --export-secret-subkeys) to our CI workflows. The import currently fails when a signing subkey should be used instead of the master secret key. 

See example of failure in https://github.com/eclipse/transformer/runs/799412866#step:5:24. This is caused by the fact that the passphrase is associated with the first found keygrip for a given set of keys. In our case, we need to find the keygrip for the fingerprint of the subkey. 

The proposed solution is to let user specify the fingerprint of the key to be used as an environment variable (and find the keygrip of said fingerprint).