### PR TITLE
Added workdir option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
   git_committer_email:
     description: 'Commit author''s email'
     required: false
+  workdir:
+    description: 'Working directory to run action in.'
+    required: false
 
 outputs:
   fingerprint:

--- a/dist/index.js
+++ b/dist/index.js
@@ -295,6 +295,11 @@ function run() {
             const git_push_gpgsign = /true/i.test(core.getInput('git_push_gpgsign'));
             const git_committer_name = core.getInput('git_committer_name');
             const git_committer_email = core.getInput('git_committer_email');
+            const workdir = core.getInput('workdir') || '.';
+            if (workdir && workdir !== '.') {
+                core.info(`📂 Using ${workdir} as working directory...`);
+                process.chdir(workdir);
+            }
             core.info('📣 GnuPG info');
             const version = yield gpg.getVersion();
             const dirs = yield gpg.getDirs();


### PR DESCRIPTION
I have projects where I am checking out multiple repos to different directories. To support running this action on a git repo that was in a different directory I had to add the workdir input option. I have tested and it works as desired.