### PR TITLE
Add workdir input

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Become a sponsor](https://img.shields.io/badge/sponsor-crazy--max-181717.svg?logo=github&style=flat-square)](https://github.com/sponsors/crazy-max)
 [![Paypal Donate](https://img.shields.io/badge/donate-paypal-00457c.svg?logo=paypal&style=flat-square)](https://www.paypal.me/crazyws)
 
-## About
+## About <!-- omit in toc -->
 
 GitHub Action to easily import a GPG key.
 
@@ -15,19 +15,18 @@ If you are interested, [check out](https://git.io/Je09Y) my other :octocat: GitH
 
 ___
 
-- [About](#about)
-- [Features](#features)
-- [Prerequisites](#prerequisites)
-- [Usage](#usage)
-  - [Workflow](#workflow)
-  - [Sign commits](#sign-commits)
-- [Customizing](#customizing)
-  - [inputs](#inputs)
-  - [outputs](#outputs)
-  - [environment variables](#environment-variables)
-- [Keep up-to-date with GitHub Dependabot](#keep-up-to-date-with-github-dependabot)
-- [How can I help?](#how-can-i-help)
-- [License](#license)
+* [Features](#features)
+* [Prerequisites](#prerequisites)
+* [Usage](#usage)
+  * [Workflow](#workflow)
+  * [Sign commits](#sign-commits)
+* [Customizing](#customizing)
+  * [inputs](#inputs)
+  * [outputs](#outputs)
+  * [environment variables](#environment-variables)
+* [Keep up-to-date with GitHub Dependabot](#keep-up-to-date-with-github-dependabot)
+* [How can I help?](#how-can-i-help)
+* [License](#license)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Following inputs can be used as `step.with` keys
 | `git_push_gpgsign`**¹**               | Bool    | Sign all pushes automatically. (default `false`) |
 | `git_committer_name`**¹**             | String  | Set commit author's name (defaults to the name associated with the GPG key) |
 | `git_committer_email`**¹**            | String  | Set commit author's email (defaults to the email address associated with the GPG key) |
-| `workdir`**¹**                        | String  | Working directory (below repository root) |
+| `workdir`                             | String  | Working directory (below repository root) |
 
 > **¹** `git_user_signingkey` needs to be enabled for these inputs to be used.
 

--- a/README.md
+++ b/README.md
@@ -15,17 +15,19 @@ If you are interested, [check out](https://git.io/Je09Y) my other :octocat: GitH
 
 ___
 
-* [Features](#features)
-* [Prerequisites](#prerequisites)
-* [Usage](#usage)
-  * [Workflow](#workflow)
-  * [Sign commits](#sign-commits)
-* [Customizing](#customizing)
-  * [inputs](#inputs)
-  * [environment variables](#environment-variables)
-* [Keep up-to-date with GitHub Dependabot](#keep-up-to-date-with-github-dependabot)
-* [How can I help?](#how-can-i-help)
-* [License](#license)
+- [About](#about)
+- [Features](#features)
+- [Prerequisites](#prerequisites)
+- [Usage](#usage)
+  - [Workflow](#workflow)
+  - [Sign commits](#sign-commits)
+- [Customizing](#customizing)
+  - [inputs](#inputs)
+  - [outputs](#outputs)
+  - [environment variables](#environment-variables)
+- [Keep up-to-date with GitHub Dependabot](#keep-up-to-date-with-github-dependabot)
+- [How can I help?](#how-can-i-help)
+- [License](#license)
 
 ## Features
 
@@ -137,6 +139,7 @@ Following inputs can be used as `step.with` keys
 | `git_push_gpgsign`**¹**               | Bool    | Sign all pushes automatically. (default `false`) |
 | `git_committer_name`**¹**             | String  | Set commit author's name (defaults to the name associated with the GPG key) |
 | `git_committer_email`**¹**            | String  | Set commit author's email (defaults to the email address associated with the GPG key) |
+| `workdir`**¹**                        | String  | Working directory (below repository root) |
 
 > **¹** `git_user_signingkey` needs to be enabled for these inputs to be used.
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
   git_committer_email:
     description: 'Commit author''s email'
     required: false
+  workdir:
+    description: 'Working directory (below repository root)'
+    default: '.'
+    required: false
 
 outputs:
   fingerprint:

--- a/dist/index.js
+++ b/dist/index.js
@@ -295,6 +295,11 @@ function run() {
             const git_push_gpgsign = /true/i.test(core.getInput('git_push_gpgsign'));
             const git_committer_name = core.getInput('git_committer_name');
             const git_committer_email = core.getInput('git_committer_email');
+            const workdir = core.getInput('workdir') || '.';
+            if (workdir && workdir !== '.') {
+                core.info(`📂 Using ${workdir} as working directory...`);
+                process.chdir(workdir);
+            }
             core.info('📣 GnuPG info');
             const version = yield gpg.getVersion();
             const dirs = yield gpg.getDirs();

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,12 @@ async function run(): Promise<void> {
     const git_push_gpgsign = /true/i.test(core.getInput('git_push_gpgsign'));
     const git_committer_name: string = core.getInput('git_committer_name');
     const git_committer_email: string = core.getInput('git_committer_email');
+    const workdir: string = core.getInput('workdir') || '.';
+    
+    if (workdir && workdir !== '.') {
+        core.info(`📂 Using ${workdir} as working directory...`);
+        process.chdir(workdir);
+    }
 
     core.info('📣 GnuPG info');
     const version = await gpg.getVersion();

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,10 +18,10 @@ async function run(): Promise<void> {
     const git_committer_name: string = core.getInput('git_committer_name');
     const git_committer_email: string = core.getInput('git_committer_email');
     const workdir: string = core.getInput('workdir') || '.';
-    
+
     if (workdir && workdir !== '.') {
-        core.info(`📂 Using ${workdir} as working directory...`);
-        process.chdir(workdir);
+      core.info(`📂 Using ${workdir} as working directory...`);
+      process.chdir(workdir);
     }
 
     core.info('📣 GnuPG info');


### PR DESCRIPTION
I have projects where I am checking out multiple repos to different directories. To support running this action on a git repo that was in a different directory I had to add the workdir input option. 

- All steps in the [CONTRIBUTING guidelines](https://github.com/crazy-max/ghaction-import-gpg/blob/master/.github/CONTRIBUTING.md) were followed.
- All tests were passing.