### PR TITLE
Fix passphrase preset: set passphrase for all key keygrips

### DIFF
--- a/__tests__/gpg.test.ts
+++ b/__tests__/gpg.test.ts
@@ -18,7 +18,10 @@ const userInfo = {
   email: 'joe@foo.bar',
   keyID: 'D523BD50DD70B0BA',
   fingerprint: '27571A53B86AF0C799B38BA77D851EB72D73BDA0',
-  keygrip: '3E2D1142AA59E08E16B7E2C64BA6DDC773B1A627'
+  keygrips: [
+    '3E2D1142AA59E08E16B7E2C64BA6DDC773B1A627',
+    'BA83FC8947213477F28ADC019F6564A956456163',
+  ]
 };
 
 describe('gpg', () => {
@@ -58,12 +61,15 @@ describe('gpg', () => {
     });
   });
 
-  describe('getKeygrip', () => {
-    it('returns the keygrip', async () => {
+  describe('getKeygrips', () => {
+    it('returns the keygrips', async () => {
       await gpg.importKey(userInfo.pgp);
-      await gpg.getKeygrip(userInfo.fingerprint).then(keygrip => {
-        console.log(keygrip);
-        expect(keygrip).toEqual(userInfo.keygrip);
+      await gpg.getKeygrips(userInfo.fingerprint).then(keygrips => {
+        console.log(keygrips);
+        expect(keygrips.length).toEqual(userInfo.keygrips.length);
+        for (let i = 0; i < keygrips.length; i++) {
+          expect(keygrips[i]).toEqual(userInfo.keygrips[i]);
+        }
       });
     });
   });
@@ -77,12 +83,13 @@ describe('gpg', () => {
   describe('presetPassphrase', () => {
     it('presets passphrase', async () => {
       await gpg.importKey(userInfo.pgp);
-      const keygrip = await gpg.getKeygrip(userInfo.fingerprint);
       await gpg.configureAgent(gpg.agentConfig);
-      await gpg.presetPassphrase(keygrip, userInfo.passphrase).then(output => {
-        console.log(output);
-        expect(output).not.toEqual('');
-      });
+      for (let keygrip of await gpg.getKeygrips(userInfo.fingerprint)) {
+        await gpg.presetPassphrase(keygrip, userInfo.passphrase).then(output => {
+          console.log(output);
+          expect(output).not.toEqual('');
+        });
+      }
     });
   });
 

--- a/src/gpg.ts
+++ b/src/gpg.ts
@@ -124,19 +124,19 @@ export const importKey = async (key: string): Promise<string> => {
     });
 };
 
-export const getKeygrip = async (fingerprint: string): Promise<string> => {
+
+export const getKeygrips = async (fingerprint: string): Promise<Array<string>> => {
   return await exec.exec('gpg', ['--batch', '--with-colons', '--with-keygrip', '--list-secret-keys', fingerprint], true).then(res => {
     if (res.stderr != '' && !res.success) {
       throw new Error(res.stderr);
     }
-    let keygrip: string = '';
+    let keygrips: Array<string> = [];
     for (let line of res.stdout.replace(/\r/g, '').trim().split(/\n/g)) {
       if (line.startsWith('grp')) {
-        keygrip = line.replace(/(grp|:)/g, '').trim();
-        break;
+        keygrips.push(line.replace(/(grp|:)/g, '').trim());
       }
     }
-    return keygrip;
+    return keygrips;
   });
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,14 +50,15 @@ async function run(): Promise<void> {
       core.info('⚙️ Configuring GnuPG agent');
       await gpg.configureAgent(gpg.agentConfig);
 
-      core.info('📌 Getting keygrip');
-      const keygrip = await gpg.getKeygrip(privateKey.fingerprint);
-      core.debug(`${keygrip}`);
+      core.info('📌 Getting keygrips');
+      const keygrips = await gpg.getKeygrips(privateKey.fingerprint);
 
-      core.info('🔓 Presetting passphrase');
-      await gpg.presetPassphrase(keygrip, process.env.PASSPHRASE).then(stdout => {
-        core.debug(stdout);
-      });
+      for (let keygrip of await gpg.getKeygrips(privateKey.fingerprint)) {
+        core.info(`🔓 Presetting passphrase for ${keygrip}`);
+        await gpg.presetPassphrase(keygrip, process.env.PASSPHRASE).then(stdout => {
+          core.debug(stdout);
+        });
+      }
     }
 
     core.info('🛒 Setting outputs...');


### PR DESCRIPTION
If a key contains multiple keygrips, then the passphrase preset
should be applied on each keygrip


could fix issues such as:
https://github.com/goreleaser/goreleaser-action/issues/201