### PR TITLE
Delete key using the primary key ID not the subkey ID

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -444,6 +444,7 @@ function run() {
                 fingerprint = inputs.fingerprint;
             }
             stateHelper.setFingerprint(fingerprint);
+            stateHelper.setKeyID(privateKey.keyID);
             yield core.group(`Fingerprint to use`, () => __awaiter(this, void 0, void 0, function* () {
                 core.info(fingerprint);
             }));
@@ -526,7 +527,7 @@ function cleanup() {
         }
         try {
             core.info('Removing keys');
-            yield gpg.deleteKey(stateHelper.fingerprint);
+            yield gpg.deleteKey(stateHelper.keyId);
             core.info('Killing GnuPG agent');
             yield gpg.killAgent();
         }
@@ -644,14 +645,19 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.setFingerprint = exports.fingerprint = exports.IsPost = void 0;
+exports.setKeyID = exports.setFingerprint = exports.keyId = exports.fingerprint = exports.IsPost = void 0;
 const core = __importStar(__webpack_require__(2186));
 exports.IsPost = !!process.env['STATE_isPost'];
 exports.fingerprint = process.env['STATE_fingerprint'] || '';
+exports.keyId = process.env['STATE_keyId'] || '';
 function setFingerprint(fingerprint) {
     core.saveState('fingerprint', fingerprint);
 }
 exports.setFingerprint = setFingerprint;
+function setKeyID(keyID) {
+    core.saveState('keyId', keyID);
+}
+exports.setKeyID = setKeyID;
 if (!exports.IsPost) {
     core.saveState('isPost', 'true');
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ async function run(): Promise<void> {
       fingerprint = inputs.fingerprint;
     }
     stateHelper.setFingerprint(fingerprint);
+    stateHelper.setKeyID(privateKey.keyID);
     await core.group(`Fingerprint to use`, async () => {
       core.info(fingerprint);
     });
@@ -131,7 +132,7 @@ async function cleanup(): Promise<void> {
   }
   try {
     core.info('Removing keys');
-    await gpg.deleteKey(stateHelper.fingerprint);
+    await gpg.deleteKey(stateHelper.keyId);
 
     core.info('Killing GnuPG agent');
     await gpg.killAgent();

--- a/src/state-helper.ts
+++ b/src/state-helper.ts
@@ -2,9 +2,14 @@ import * as core from '@actions/core';
 
 export const IsPost = !!process.env['STATE_isPost'];
 export const fingerprint = process.env['STATE_fingerprint'] || '';
+export const keyId = process.env['STATE_keyId'] || '';
 
 export function setFingerprint(fingerprint: string) {
   core.saveState('fingerprint', fingerprint);
+}
+
+export function setKeyID(keyID: string) {
+  core.saveState('keyId', keyID);
 }
 
 if (!IsPost) {


### PR DESCRIPTION
Issue: https://github.com/crazy-max/ghaction-import-gpg/issues/124

As I've explained in that issue. The command to delete the key at the end of the workflow fails. It's failing because it's using the fingerprint of the subkey. I think you cannot delete only a subkey and you have to use either a name or the fingerprint of the primary key.

I've changed the code to store the KeyID in the state together with the fingerprint used, in order to use the primary key fingerprint.

I've not tested yet if that works.