### PR TITLE
Fix error deleting keys with short key id

### DIFF
--- a/__tests__/gpg.test.ts
+++ b/__tests__/gpg.test.ts
@@ -20,6 +20,7 @@ const userInfos = [
     name: 'Joe Tester',
     email: 'joe@foo.bar',
     keyID: '7D851EB72D73BDA0',
+    primary_key_fingerprint: '27571A53B86AF0C799B38BA77D851EB72D73BDA0',
     fingerprint: '27571A53B86AF0C799B38BA77D851EB72D73BDA0',
     fingerprints: ['27571A53B86AF0C799B38BA77D851EB72D73BDA0', '5A282E1460C0BC419615D34DD523BD50DD70B0BA'],
     keygrips: ['3E2D1142AA59E08E16B7E2C64BA6DDC773B1A627', 'BA83FC8947213477F28ADC019F6564A956456163']
@@ -41,6 +42,7 @@ const userInfos = [
     name: 'Joe Bar',
     email: 'joe@bar.foo',
     keyID: '6071D218380FDCC8',
+    primary_key_fingerprint: '87F257B89CE462100BEC0FFE6071D218380FDCC8',
     fingerprint: 'C17D11ADF199F12A30A0910F1F80449BE0B08CB8',
     fingerprints: ['87F257B89CE462100BEC0FFE6071D218380FDCC8', 'C17D11ADF199F12A30A0910F1F80449BE0B08CB8'],
     keygrips: ['F5C3ABFAAB36B427FD98C4EDD0387E08EA1E8092', 'DEE0FC98F441519CA5DE5D79773CB29009695FEB']
@@ -133,7 +135,7 @@ for (let userInfo of userInfos) {
     describe('deleteKey', () => {
       it('removes key from GnuPG', async () => {
         await gpg.importKey(userInfo.pgp);
-        await gpg.deleteKey(userInfo.fingerprint);
+        await gpg.deleteKey(userInfo.primary_key_fingerprint);
       });
     });
   });

--- a/dist/index.js
+++ b/dist/index.js
@@ -439,12 +439,11 @@ function run() {
                 core.info(`Email        : ${privateKey.email}`);
                 core.info(`CreationTime : ${privateKey.creationTime}`);
             }));
+            stateHelper.setFingerprint(privateKey.fingerprint);
             let fingerprint = privateKey.fingerprint;
             if (inputs.fingerprint) {
                 fingerprint = inputs.fingerprint;
             }
-            stateHelper.setFingerprint(fingerprint);
-            stateHelper.setKeyID(privateKey.keyID);
             yield core.group(`Fingerprint to use`, () => __awaiter(this, void 0, void 0, function* () {
                 core.info(fingerprint);
             }));
@@ -522,12 +521,12 @@ function run() {
 function cleanup() {
     return __awaiter(this, void 0, void 0, function* () {
         if (stateHelper.fingerprint.length <= 0) {
-            core.debug('Fingerprint is not defined. Skipping cleanup.');
+            core.debug('Primary key fingerprint is not defined. Skipping cleanup.');
             return;
         }
         try {
-            core.info('Removing keys');
-            yield gpg.deleteKey(stateHelper.keyId);
+            core.info(`Removing key ${stateHelper.fingerprint}`);
+            yield gpg.deleteKey(stateHelper.fingerprint);
             core.info('Killing GnuPG agent');
             yield gpg.killAgent();
         }
@@ -645,19 +644,14 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.setKeyID = exports.setFingerprint = exports.keyId = exports.fingerprint = exports.IsPost = void 0;
+exports.setFingerprint = exports.fingerprint = exports.IsPost = void 0;
 const core = __importStar(__webpack_require__(2186));
 exports.IsPost = !!process.env['STATE_isPost'];
 exports.fingerprint = process.env['STATE_fingerprint'] || '';
-exports.keyId = process.env['STATE_keyId'] || '';
 function setFingerprint(fingerprint) {
     core.saveState('fingerprint', fingerprint);
 }
 exports.setFingerprint = setFingerprint;
-function setKeyID(keyID) {
-    core.saveState('keyId', keyID);
-}
-exports.setKeyID = setKeyID;
 if (!exports.IsPost) {
     core.saveState('isPost', 'true');
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,12 +33,13 @@ async function run(): Promise<void> {
       core.info(`CreationTime : ${privateKey.creationTime}`);
     });
 
+    stateHelper.setFingerprint(privateKey.fingerprint);
+
     let fingerprint = privateKey.fingerprint;
     if (inputs.fingerprint) {
       fingerprint = inputs.fingerprint;
     }
-    stateHelper.setFingerprint(fingerprint);
-    stateHelper.setKeyID(privateKey.keyID);
+
     await core.group(`Fingerprint to use`, async () => {
       core.info(fingerprint);
     });
@@ -127,12 +128,12 @@ async function run(): Promise<void> {
 
 async function cleanup(): Promise<void> {
   if (stateHelper.fingerprint.length <= 0) {
-    core.debug('Fingerprint is not defined. Skipping cleanup.');
+    core.debug('Primary key fingerprint is not defined. Skipping cleanup.');
     return;
   }
   try {
-    core.info('Removing keys');
-    await gpg.deleteKey(stateHelper.keyId);
+    core.info(`Removing key ${stateHelper.fingerprint}`);
+    await gpg.deleteKey(stateHelper.fingerprint);
 
     core.info('Killing GnuPG agent');
     await gpg.killAgent();

--- a/src/state-helper.ts
+++ b/src/state-helper.ts
@@ -2,14 +2,9 @@ import * as core from '@actions/core';
 
 export const IsPost = !!process.env['STATE_isPost'];
 export const fingerprint = process.env['STATE_fingerprint'] || '';
-export const keyId = process.env['STATE_keyId'] || '';
 
 export function setFingerprint(fingerprint: string) {
   core.saveState('fingerprint', fingerprint);
-}
-
-export function setKeyID(keyID: string) {
-  core.saveState('keyId', keyID);
 }
 
 if (!IsPost) {


### PR DESCRIPTION
Relates to: https://github.com/crazy-max/ghaction-import-gpg/issues/124#issuecomment-1057105337

Error:

```
gpg: can't do this in batch mode
```

The GPG command:

```
gpg --batch --yes --delete-secret-keys FINGERPRINT
```

requires to use a fingerprint if you use the `--batch` option.

We were using the short ID of the primary key.