### PR TITLE
Add `name` output to action metadata

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,8 @@ outputs:
     description: 'Fingerprint of the GPG key (recommended as user ID)'
   keyid:
     description: 'Low 64 bits of the X.509 certificate SHA-1 fingerprint'
+  name:
+    description: 'Name associated with the GPG key'
   email:
     description: 'Email address associated with the GPG key'
 


### PR DESCRIPTION
This output parameter was introduced at https://github.com/crazy-max/ghaction-import-gpg/commit/aca1ab6f618ec242c60cb8bd4ad878e8180c3d29 and already available, but not declared in metadata.